### PR TITLE
fix: Remove misleading progress indicators and implement proper group…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { LandingPage } from './pages/Landing';
 import { Groups } from './pages/Groups/Groups-new';
 
-type PageType = 'landing' | 'groups' | 'create' | 'profile';
+type PageType = 'landing' | 'groups' | 'create-public' | 'create-private' | 'profile';
 
 function App() {
   const [currentPage, setCurrentPage] = useState<PageType>('landing');
@@ -19,7 +19,7 @@ function App() {
   const navigationProps = {
     onNavigateHome: () => setCurrentPage('landing'),
     onNavigateGroups: () => setCurrentPage('groups'),
-    onNavigateCreate: () => setCurrentPage('create'),
+    onNavigateCreate: () => setCurrentPage('create-public'), // Default to public
     onConnectWallet: handleConnectWallet,
     isWalletConnected,
     walletAddress
@@ -29,12 +29,36 @@ function App() {
     return <Groups {...navigationProps} />;
   }
 
-  if (currentPage === 'create') {
+  if (currentPage === 'create-public') {
     return (
       <div style={{ padding: '100px 20px', textAlign: 'center' }}>
-        <h1>Create Group Page</h1>
-        <p>This page will be built next!</p>
-        <button onClick={() => setCurrentPage('landing')}>Back to Home</button>
+        <h1>Create Public Group Page</h1>
+        <p>Open to anyone - This page will be built next!</p>
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'center', marginTop: '20px' }}>
+          <button onClick={() => setCurrentPage('create-private')} style={{ padding: '10px 20px' }}>
+            Switch to Private
+          </button>
+          <button onClick={() => setCurrentPage('landing')} style={{ padding: '10px 20px' }}>
+            Back to Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (currentPage === 'create-private') {
+    return (
+      <div style={{ padding: '100px 20px', textAlign: 'center' }}>
+        <h1>Create Private Group Page</h1>
+        <p>Invite-only groups - This page will be built next!</p>
+        <div style={{ display: 'flex', gap: '10px', justifyContent: 'center', marginTop: '20px' }}>
+          <button onClick={() => setCurrentPage('create-public')} style={{ padding: '10px 20px' }}>
+            Switch to Public
+          </button>
+          <button onClick={() => setCurrentPage('landing')} style={{ padding: '10px 20px' }}>
+            Back to Home
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/Groups/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/Groups/FilterBar/FilterBar.tsx
@@ -5,6 +5,7 @@ import styles from '../../../styles/components/Groups/FilterBar.module.css';
 export interface FilterOptions {
   status: string[];
   riskLevel: string[];
+  groupType: string[];
   contributionRange: [number, number];
   sortBy: string;
 }
@@ -23,6 +24,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   const [activeFilters, setActiveFilters] = useState<FilterOptions>({
     status: [],
     riskLevel: [],
+    groupType: [],
     contributionRange: [0, 1000],
     sortBy: 'newest'
   });
@@ -39,6 +41,11 @@ export const FilterBar: React.FC<FilterBarProps> = ({
     { value: 'high', label: 'High Risk', color: '#ef4444' }
   ];
 
+  const typeOptions = [
+    { value: 'public', label: 'Public', color: '#10b981' },
+    { value: 'private', label: 'Private', color: '#8b5cf6' }
+  ];
+
   const sortOptions = [
     { value: 'newest', label: 'Newest First' },
     { value: 'oldest', label: 'Oldest First' },
@@ -49,7 +56,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   ];
 
   const toggleFilter = (type: keyof FilterOptions, value: string) => {
-    if (type === 'status' || type === 'riskLevel') {
+    if (type === 'status' || type === 'riskLevel' || type === 'groupType') {
       const currentValues = activeFilters[type] as string[];
       const newValues = currentValues.includes(value)
         ? currentValues.filter(v => v !== value)
@@ -71,6 +78,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
     const defaultFilters: FilterOptions = {
       status: [],
       riskLevel: [],
+      groupType: [],
       contributionRange: [0, 1000],
       sortBy: 'newest'
     };
@@ -82,6 +90,7 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   const hasActiveFilters = 
     activeFilters.status.length > 0 || 
     activeFilters.riskLevel.length > 0 ||
+    activeFilters.groupType.length > 0 ||
     searchTerm.length > 0;
 
   return (
@@ -139,6 +148,28 @@ export const FilterBar: React.FC<FilterBarProps> = ({
                   style={{
                     borderColor: activeFilters.riskLevel.includes(option.value) ? option.color : undefined,
                     backgroundColor: activeFilters.riskLevel.includes(option.value) ? `${option.color}20` : undefined
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Group Type Filters */}
+          <div className={styles.filterGroup}>
+            <span className={styles.filterLabel}>Type:</span>
+            <div className={styles.filterOptions}>
+              {typeOptions.map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => toggleFilter('groupType', option.value)}
+                  className={`${styles.filterChip} ${
+                    activeFilters.groupType.includes(option.value) ? styles.active : ''
+                  }`}
+                  style={{
+                    borderColor: activeFilters.groupType.includes(option.value) ? option.color : undefined,
+                    backgroundColor: activeFilters.groupType.includes(option.value) ? `${option.color}20` : undefined
                   }}
                 >
                   {option.label}

--- a/frontend/src/components/Groups/GroupCard/GroupCard.tsx
+++ b/frontend/src/components/Groups/GroupCard/GroupCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from '../../ui';
-import type { GroupStatus } from '../../../constants';
+import type { GroupStatus, GroupType } from '../../../constants';
 import styles from '../../../styles/components/Groups/GroupCard.module.css';
 
 export interface Group {
@@ -10,11 +10,10 @@ export interface Group {
   contributionAmount: number;
   currency: string;
   currentMembers: number;
-  maxMembers: number;
+  type: GroupType;
   status: GroupStatus;
   timeRemaining: string;
   totalContributed: number;
-  targetAmount: number;
   riskLevel: 'low' | 'medium' | 'high';
   createdBy: string;
   createdAt: Date;
@@ -32,8 +31,6 @@ export const GroupCard: React.FC<GroupCardProps> = ({
   onJoin,
   isWalletConnected
 }) => {
-  const progressPercentage = (group.totalContributed / group.targetAmount) * 100;
-  
   const getRiskColor = (risk: string) => {
     switch (risk) {
       case 'low': return '#10b981';
@@ -53,7 +50,15 @@ export const GroupCard: React.FC<GroupCardProps> = ({
     }
   };
 
-  const isJoinable = group.status === 'active' && group.currentMembers < group.maxMembers;
+  const getTypeColor = (type: GroupType) => {
+    switch (type) {
+      case 'public': return '#10b981';
+      case 'private': return '#8b5cf6';
+      default: return '#6b7280';
+    }
+  };
+
+  const isJoinable = group.status === 'active' && group.type === 'public';
 
   return (
     <div className={styles.groupCard}>
@@ -66,6 +71,12 @@ export const GroupCard: React.FC<GroupCardProps> = ({
               style={{ backgroundColor: getStatusColor(group.status) }}
             >
               {group.status}
+            </span>
+            <span 
+              className={styles.typeBadge}
+              style={{ backgroundColor: getTypeColor(group.type) }}
+            >
+              {group.type}
             </span>
             <span 
               className={styles.riskBadge}
@@ -93,27 +104,18 @@ export const GroupCard: React.FC<GroupCardProps> = ({
         <div className={styles.statItem}>
           <span className={styles.statLabel}>Members</span>
           <span className={styles.statValue}>
-            {group.currentMembers}/{group.maxMembers}
+            {group.currentMembers} {group.currentMembers === 1 ? 'member' : 'members'}
           </span>
         </div>
       </div>
 
-      <div className={styles.progress}>
-        <div className={styles.progressHeader}>
-          <span className={styles.progressLabel}>Progress</span>
-          <span className={styles.progressAmount}>
-            {group.totalContributed}/{group.targetAmount} {group.currency}
+      <div className={styles.totalSection}>
+        <div className={styles.totalHeader}>
+          <span className={styles.totalLabel}>Total Pool</span>
+          <span className={styles.totalAmount}>
+            {group.totalContributed} {group.currency}
           </span>
         </div>
-        <div className={styles.progressBar}>
-          <div 
-            className={styles.progressFill}
-            style={{ width: `${Math.min(progressPercentage, 100)}%` }}
-          />
-        </div>
-        <span className={styles.progressPercentage}>
-          {Math.round(progressPercentage)}% funded
-        </span>
       </div>
 
       <div className={styles.tags}>
@@ -135,6 +137,15 @@ export const GroupCard: React.FC<GroupCardProps> = ({
           >
             {isWalletConnected ? 'Join Group' : 'Connect Wallet to Join'}
           </Button>
+        ) : group.type === 'private' && group.status === 'active' ? (
+          <Button 
+            variant="ghost"
+            size="md"
+            disabled
+            className={styles.viewButton}
+          >
+            Private - Invite Only
+          </Button>
         ) : (
           <Button 
             variant="ghost"
@@ -143,7 +154,7 @@ export const GroupCard: React.FC<GroupCardProps> = ({
             className={styles.viewButton}
           >
             {group.status === 'completed' ? 'View Results' : 
-             group.status === 'settling' ? 'Settling...' : 'Group Full'}
+             group.status === 'settling' ? 'Settling...' : 'Not Available'}
           </Button>
         )}
       </div>

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -42,6 +42,9 @@ export const ROUTES = {
 // Group status types
 export type GroupStatus = 'active' | 'pending' | 'settling' | 'completed';
 
+// Group visibility types
+export type GroupType = 'public' | 'private';
+
 // Mock data for groups
 export const MOCK_GROUPS = [
   {
@@ -51,15 +54,14 @@ export const MOCK_GROUPS = [
     contributionAmount: 100,
     currency: 'STX',
     currentMembers: 8,
-    maxMembers: 12,
+    type: 'public' as GroupType,
     status: 'active' as GroupStatus,
     timeRemaining: '2d 14h 30m',
     totalContributed: 800,
-    targetAmount: 1200,
     riskLevel: 'medium',
     createdBy: 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM',
     createdAt: new Date('2025-10-03'),
-    tags: ['DeFi', 'Growth', 'STX']
+    tags: ['DeFi', 'Growth', 'STX', 'Public']
   },
   {
     id: '2',
@@ -68,15 +70,14 @@ export const MOCK_GROUPS = [
     contributionAmount: 250,
     currency: 'STX',
     currentMembers: 15,
-    maxMembers: 20,
+    type: 'public' as GroupType,
     status: 'active' as GroupStatus,
     timeRemaining: '5d 8h 15m',
     totalContributed: 3750,
-    targetAmount: 5000,
     riskLevel: 'low',
     createdBy: 'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG',
     createdAt: new Date('2025-10-01'),
-    tags: ['Bitcoin', 'Conservative', 'HODL']
+    tags: ['Bitcoin', 'Conservative', 'HODL', 'Public']
   },
   {
     id: '3',
@@ -85,15 +86,14 @@ export const MOCK_GROUPS = [
     contributionAmount: 500,
     currency: 'STX',
     currentMembers: 6,
-    maxMembers: 10,
+    type: 'private' as GroupType,
     status: 'pending' as GroupStatus,
     timeRemaining: '1d 6h 45m',
     totalContributed: 3000,
-    targetAmount: 5000,
     riskLevel: 'high',
     createdBy: 'ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP',
     createdAt: new Date('2025-10-04'),
-    tags: ['DeFi', 'Yield', 'High-Risk']
+    tags: ['DeFi', 'Yield', 'High-Risk', 'Private']
   },
   {
     id: '4',
@@ -102,15 +102,14 @@ export const MOCK_GROUPS = [
     contributionAmount: 75,
     currency: 'STX',
     currentMembers: 4,
-    maxMembers: 8,
+    type: 'public' as GroupType,
     status: 'active' as GroupStatus,
     timeRemaining: '12h 20m',
     totalContributed: 300,
-    targetAmount: 600,
     riskLevel: 'high',
     createdBy: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5',
     createdAt: new Date('2025-10-05'),
-    tags: ['NFT', 'Quick-Flip', 'Trending']
+    tags: ['NFT', 'Quick-Flip', 'Trending', 'Public']
   },
   {
     id: '5',
@@ -119,15 +118,14 @@ export const MOCK_GROUPS = [
     contributionAmount: 200,
     currency: 'STX',
     currentMembers: 12,
-    maxMembers: 15,
+    type: 'private' as GroupType,
     status: 'settling' as GroupStatus,
     timeRemaining: 'Settling...',
     totalContributed: 2400,
-    targetAmount: 3000,
     riskLevel: 'low',
     createdBy: 'ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB',
     createdAt: new Date('2025-09-28'),
-    tags: ['Stable', 'Yield', 'Conservative']
+    tags: ['Stable', 'Yield', 'Conservative', 'Private']
   },
   {
     id: '6',
@@ -136,14 +134,45 @@ export const MOCK_GROUPS = [
     contributionAmount: 50,
     currency: 'STX',
     currentMembers: 20,
-    maxMembers: 25,
+    type: 'public' as GroupType,
     status: 'completed' as GroupStatus,
     timeRemaining: 'Completed',
     totalContributed: 1000,
-    targetAmount: 1250,
     riskLevel: 'high',
     createdBy: 'ST39MJ145BR6S8C315AG2BD61SJ16E208P1FDK3AK',
     createdAt: new Date('2025-09-25'),
-    tags: ['Meme', 'Moonshot', 'Speculative']
+    tags: ['Meme', 'Moonshot', 'Speculative', 'Public']
+  },
+  {
+    id: '7',
+    title: 'Elite Traders Circle',
+    description: 'Exclusive private group for experienced traders with proven track records',
+    contributionAmount: 1000,
+    currency: 'STX',
+    currentMembers: 3,
+    type: 'private' as GroupType,
+    status: 'active' as GroupStatus,
+    timeRemaining: '7d 12h 45m',
+    totalContributed: 3000,
+    riskLevel: 'high',
+    createdBy: 'ST1ELITE123TRADER456PRIVATE789ABC',
+    createdAt: new Date('2025-10-05'),
+    tags: ['Elite', 'Experienced', 'High-Stakes', 'Private']
+  },
+  {
+    id: '8',
+    title: 'Friends & Family Pool',
+    description: 'Private investment group for close friends and family members only',
+    contributionAmount: 150,
+    currency: 'STX',
+    currentMembers: 7,
+    type: 'private' as GroupType,
+    status: 'active' as GroupStatus,
+    timeRemaining: '3d 18h 30m',
+    totalContributed: 1050,
+    riskLevel: 'medium',
+    createdBy: 'ST2FAMILY789FRIENDS123PRIVATE456',
+    createdAt: new Date('2025-10-04'),
+    tags: ['Family', 'Friends', 'Trust', 'Private']
   }
 ] as const;

--- a/frontend/src/pages/Groups/Groups-new.tsx
+++ b/frontend/src/pages/Groups/Groups-new.tsx
@@ -9,12 +9,18 @@ export interface GroupsProps {
   onConnectWallet?: () => void;
   isWalletConnected?: boolean;
   walletAddress?: string;
+  onNavigateHome?: () => void;
+  onNavigateGroups?: () => void;
+  onNavigateCreate?: () => void;
 }
 
 export const Groups: React.FC<GroupsProps> = ({
   onConnectWallet,
   isWalletConnected = false,
-  walletAddress
+  walletAddress,
+  onNavigateHome,
+  onNavigateGroups,
+  onNavigateCreate
 }) => {
   const [filteredGroups] = useState(MOCK_GROUPS);
   const [searchTerm, setSearchTerm] = useState('');
@@ -29,12 +35,16 @@ export const Groups: React.FC<GroupsProps> = ({
 
   const handleCreateGroup = () => {
     console.log('Navigate to create group');
+    onNavigateCreate?.();
   };
 
   return (
     <div className={styles.groupsPage}>
       <Header 
         onConnectWallet={onConnectWallet}
+        onNavigateHome={onNavigateHome}
+        onNavigateGroups={onNavigateGroups}
+        onNavigateCreate={onNavigateCreate}
         isWalletConnected={isWalletConnected}
         walletAddress={walletAddress}
       />

--- a/frontend/src/styles/components/Groups/GroupCard.module.css
+++ b/frontend/src/styles/components/Groups/GroupCard.module.css
@@ -46,6 +46,7 @@
 }
 
 .statusBadge,
+.typeBadge,
 .riskBadge {
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
@@ -118,51 +119,35 @@
 }
 
 /* Progress Section */
-.progress {
+.totalSection {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  padding: var(--space-md);
+  background: rgba(29, 78, 216, 0.1);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(29, 78, 216, 0.2);
 }
 
-.progressHeader {
+.totalHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.progressLabel {
+.totalLabel {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
-  color: #475569;
+  color: #1d4ed8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
-.progressAmount {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: #0f172a;
-  font-family: monospace;
-}
-
-.progressBar {
-  width: 100%;
-  height: 8px;
-  background: rgba(226, 232, 240, 0.8);
-  border-radius: var(--radius-full);
-  overflow: hidden;
-}
-
-.progressFill {
-  height: 100%;
-  background: linear-gradient(90deg, #1d4ed8, #0891b2);
-  border-radius: var(--radius-full);
-  transition: width var(--transition-slow);
-}
-
-.progressPercentage {
-  font-size: var(--font-size-xs);
-  color: #64748b;
-  text-align: center;
-  font-weight: var(--font-weight-medium);
+.totalAmount {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: #1d4ed8;
+  font-family: var(--font-primary);
 }
 
 /* Tags */


### PR DESCRIPTION
… types

Key Changes:
- Remove fixed target amounts and progress bars that implied contribution limits
- Update group display to show only current totals (e.g., '800 STX' not '800/1200 STX')
- Implement public vs private group types with proper visual distinction
- Add group type filtering (Public/Private) to FilterBar
- Update member display to show current count without max limits (e.g., '8 members')

Group Type Implementation:
- Public groups: Open to anyone, show 'Join Group' button
- Private groups: Invite-only, show 'Private - Invite Only' button
- Visual badges: Green for Public, Purple for Private
- Enhanced filtering with type-specific color coding

UI/UX Improvements:
- Replace misleading progress bars with clean 'Total Pool' display
- Remove targetAmount from data structure completely
- Update navigation to support separate public/private group creation
- Add 2 additional mock groups (Elite Traders Circle, Friends & Family Pool)

Technical Updates:
- Update GroupCard interface to remove targetAmount field
- Enhance FilterBar with groupType filtering support
- Update App routing for create-public and create-private pages
- Maintain mobile responsiveness across all new components

This aligns with the requirement that groups have unlimited growth potential and removes any artificial limits on member count or contribution amounts.